### PR TITLE
Remove the --y-resolution arg from the scanadf call

### DIFF
--- a/scanpdf/scanpdf.py
+++ b/scanpdf/scanpdf.py
@@ -80,7 +80,6 @@ class ScanPdf(object):
                 '--source "ADF Duplex"',
                 '--mode Color',
                 '--resolution %sdpi' % self.dpi,
-                '--y-resolution %sdpi' % self.dpi,
                 '-o %s/page_%%04d' % self.tmp_dir,
                 '-y 876',
                 '--page-height 376',


### PR DESCRIPTION
This argument was removed in sane-backends 1.0.20.